### PR TITLE
Removed hard coded file names in ssl setup script

### DIFF
--- a/files/hooks/entrypoint-pre.d/19_doc_root_setup
+++ b/files/hooks/entrypoint-pre.d/19_doc_root_setup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #Setting document root
 
 if [ ! -d "/var/www/$DOCUMENT_ROOT" ]; then

--- a/files/hooks/entrypoint-pre.d/20_ssl_setup
+++ b/files/hooks/entrypoint-pre.d/20_ssl_setup
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+#
 #  SSL Configuration.
 #
 

--- a/files/hooks/entrypoint-pre.d/20_ssl_setup
+++ b/files/hooks/entrypoint-pre.d/20_ssl_setup
@@ -40,8 +40,8 @@ elif [[ ! -z "$SSL_KEY" ]] && [[ ! -z "$SSL_CERT" ]]; then
     cp /etc/nginx/sites-enabled/site.conf /tmp
     sed -i -e 's/# listen 443/listen 8443/g' /tmp/site.conf
     sed -i -e 's/# listen \[::\]:443/listen \[::\]:8443/g' /tmp/site.conf
-    sed -i -e '/server_name _;/a \        ssl\_certificate\_key \/ssl\/ssl\.key\;' /tmp/site.conf
-    sed -i -e '/server_name _;/a \        ssl\_certificate \/ssl\/ssl\.crt\;' /tmp/site.conf
+    sed -i -e "/server_name _;/a \        ssl\_certificate\_key ${SSL_KEY}\;" /tmp/site.conf
+    sed -i -e "/server_name _;/a \        ssl\_certificate ${SSL_CERT}\;" /tmp/site.conf
     cat /tmp/site.conf > /etc/nginx/sites-enabled/site.conf
   fi
 

--- a/files/hooks/supervisord-pre.d/20_test_files_setup
+++ b/files/hooks/supervisord-pre.d/20_test_files_setup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # If our document root is empty - then copy over a suite of test files
 echo -n "Checking if /var/www/$DOCUMENT_ROOT is empty - "

--- a/files/hooks/supervisord-pre.d/21_cleanup_log_files
+++ b/files/hooks/supervisord-pre.d/21_cleanup_log_files
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check to see if user has set number of logfiles to keep:
 


### PR DESCRIPTION
Fix for the file names passed into the ssl setup script not being honoured in the nginx configuration.