### PR TITLE
Run the status page on it's own port

### DIFF
--- a/files/etc/nginx/sites-enabled/site.conf
+++ b/files/etc/nginx/sites-enabled/site.conf
@@ -68,13 +68,6 @@ server {
 		access_log off;
 	}
 
-  location /nginx_status {
-    stub_status on;
-    access_log   off;
-    allow 127.0.0.1;
-    deny all;
-  }
-
 	# pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
 	#
 	#location ~ \.php$ {

--- a/files/etc/nginx/sites-enabled/status.conf
+++ b/files/etc/nginx/sites-enabled/status.conf
@@ -1,0 +1,11 @@
+server {
+	listen 8081 default_server;
+	listen [::]:8081 default_server;
+
+  location = /nginx_status {
+    stub_status on;
+    access_log   off;
+    allow 127.0.0.1;
+    deny all;
+  }
+}


### PR DESCRIPTION
Derivative images allow breakage of the status page otherwise